### PR TITLE
fix for sveltekit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 *.log
 *.lock
 pnpm-lock.yaml
+package-lock.json
 /dist

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "svelte-recaptcha-v2",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Google ReCaptcha v2 implementation for Svelte and SvelteKit",
     "scripts": {
         "build": "rollup -c",
@@ -49,6 +49,6 @@
         "svelte": "^3.44.0"
     },
     "dependencies": {
-        "debug": "^4.3.2"
+        "debug": "npm:@milahu/debug-esm@^4.3.5"
     }
 }

--- a/src/lib/browser.js
+++ b/src/lib/browser.js
@@ -1,3 +1,4 @@
-export const browser = (() => {
+const browser = (() => {
     return typeof window === "object" && typeof window.document === "object";
 })();
+export default browser;

--- a/src/lib/defer.js
+++ b/src/lib/defer.js
@@ -1,4 +1,4 @@
-export const defer = () => {
+const defer = () => {
     var res, rej;
 
     var promise = new Promise((resolve, reject) => {
@@ -11,3 +11,5 @@ export const defer = () => {
 
     return promise;
 };
+
+export default defer;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,2 +1,0 @@
-export { defer } from "./defer";
-export { browser } from "./browser";


### PR DESCRIPTION
I am kinda new to this but this should do it.

I replaced "debug" with "@milahu/debug-esm" which is an esm fork of debug. Keep in mind debug v5 will support esm and you should switch back.

I also fixed the lib exports as vite would nag about default exporting.

P.S. You should include the src of the demo so we can test it faster. Remember to load the recaptcha key from env and exclude that in .gitignore